### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ jsonfield==2.0.2
 kombu==4.1.0
 libmagic==1.0
 meld3==1.0.2
-psycopg2==2.7.1
+psycopg2
 python-magic==0.4.15
 python-memcached==1.59
 pytz==2018.3


### PR DESCRIPTION
Ubuntu 18.04:
Error loading psycopg2 module: .../env/local/lib/python2.7/site-packages/psycopg2/.libs/libresolv-2-c4c53def.5.so: symbol __res_maybe_init version GLIBC_PRIVATE not defined in file libc.so.6 with link time reference

Fix:
$ pip uninstall psycopg2
$ pip install psycopg2
Successfully installed psycopg2-2.7.5