### PR TITLE
[fix] Fix delete_findings_api

### DIFF
--- a/findings/apis.py
+++ b/findings/apis.py
@@ -43,7 +43,7 @@ def get_finding_api(request, finding_id):
 
 @api_view(['POST'])
 def delete_findings_api(request):
-    findings = json.loads(request.body)
+    findings = request.data
     for finding_id in findings:
         f = Finding.objects.get(id=finding_id)
 


### PR DESCRIPTION
Deleting findings was impossible. I've applied the same fix than earlier.

```
  File "/opt/PatrowlManager/findings/apis.py", line 63, in delete_findings_api
    findings = json.loads(request.body)
  File "/usr/local/lib/python2.7/dist-packages/rest_framework/request.py", line 410, in __getattr__
    return getattr(self._request, attr)
  File "/usr/local/lib/python2.7/dist-packages/django/http/request.py", line 264, in body
    raise RawPostDataException("You cannot access body after reading from request's data stream")
RawPostDataException: You cannot access body after reading from request's data stream
```