### PR TITLE
Bugfix: remove a dangling s character in the href for the "Refresh all scores" link

### DIFF
--- a/assets/templates/list-assets.html
+++ b/assets/templates/list-assets.html
@@ -31,7 +31,7 @@ function toggle(source, element) {
 <div class="container-fluid">
 
   <a href="{% url 'export_assets_api' %}" class="text-warning">>> Export assets (CSV)</a><br/>
-  <a href="{% url 'refresh_all_asset_grade_api' %}s" class="text-danger">>> Refresh all scores</a><br/>
+  <a href="{% url 'refresh_all_asset_grade_api' %}" class="text-danger">>> Refresh all scores</a><br/>
 
   <div id="menu_tabs" class="container-fluid">
     <ul class="nav nav-tabs" id="menu_tabs_ul">


### PR DESCRIPTION
The `list-assets.html` view had a trailing "s" character in the href reference to the relevant API call, this PR simply removes that character 