### PR TITLE
[rules][thehive] Fix error log and severity

### DIFF
--- a/findings/apis.py
+++ b/findings/apis.py
@@ -180,8 +180,8 @@ def send_finding_alerts_api(request, finding_id):
     elif request.GET.get("type", None) and request.GET.get("type") == "thehive":
         rule.target = "thehive"
         rule.notify(message=finding.title, asset=finding.asset, description=finding.description)
-    elif request.GET.get("type", None) and request.GET.get("type") == "mail":
-        rule.target = "mail"
+    elif request.GET.get("type", None) and request.GET.get("type") == "email":
+        rule.target = "email"
         rule.notify(message=finding.title, asset=finding.asset, description=finding.description)
 
     rule.delete()

--- a/scans/templates/details-scan.html
+++ b/scans/templates/details-scan.html
@@ -616,7 +616,7 @@ function toggle(source, element) {
             <dd>
               <button type="button" class="btn btn-xs btn-default btn-alert-finding" alert-type="thehive">TheHive</button>
               <button type="button" class="btn btn-xs btn-default btn-alert-finding" alert-type="slack">Slack</button>
-              <button type="button" class="btn btn-xs btn-default btn-alert-finding" alert-type="mail">Mail</button>
+              <button type="button" class="btn btn-xs btn-default btn-alert-finding" alert-type="email">Mail</button>
               <i class="alerts_summary"></i>
             </dd>
           </dl>


### PR DESCRIPTION
**Fixtures**:
- Delete "message" and "description" in the log (sometimes too long and crash, limit to 250)
- Severity 0 does not exist for TheHive: setting the default value to 1 (which is "low" for TheHive).
- Delete "message" in the error message to increase the error message to 40
- Separate log message in a var and get only the first 250 characters.
- Fix "mail" type into "email" in api

**Ideas**:
  - Use a log middleware to sanitize log input (remove \n, cut length)