### PR TITLE
Dockerfile for faster build on file change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ LABEL Name="Patrowl Manager" Version="1.1.2"
 ENV PYTHONUNBUFFERED 1
 RUN mkdir -p /opt/patrowl-manager/
 WORKDIR /opt/patrowl-manager/
-COPY . /opt/patrowl-manager/
-COPY app/settings.py.sample /opt/patrowl-manager/app/settings.py
 
 RUN apt-get update -yq
 # RUN apt-get install -yq --no-install-recommends apt-utils python3 python3-pip python3-virtualenv libmagic-dev
@@ -14,10 +12,15 @@ RUN apt-get install -yq --no-install-recommends apt-utils python3 python3-pip li
 RUN apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+ADD ./requirements.txt /root/
+
 RUN python --version
 RUN pip3 install virtualenv
 RUN virtualenv env3
-RUN /opt/patrowl-manager/env3/bin/pip3 install -r requirements.txt
+RUN /opt/patrowl-manager/env3/bin/pip3 install -r /root/requirements.txt
+
+COPY . /opt/patrowl-manager/
+COPY app/settings.py.sample /opt/patrowl-manager/app/settings.py
 
 EXPOSE 8003
 ENTRYPOINT ["/opt/patrowl-manager/docker-entrypoint.sh"]


### PR DESCRIPTION
When changing a python file in the project, `apt-get install` and `pip install` will be using cache and only the lines 22 to 27 will be run again.
Making the build process faster on python file changes.