### PR TITLE
Fixes #175 by not replacing the whole `scan_params` dictionary key

### DIFF
--- a/scans/views.py
+++ b/scans/views.py
@@ -412,10 +412,8 @@ def add_scan_def_view(request):
                 parameters.update({
                     "engine_id": EngineInstance.objects.get(id=form.data['engine_id']).id
                 })
-                parameters.update({
-                    "scan_params": {
-                        "engine_id": EngineInstance.objects.get(id=form.data['engine_id']).id
-                    }
+                parameters['scan_params'].update({
+                    "engine_id": EngineInstance.objects.get(id=form.data['engine_id']).id
                 })
 
             # todo: check if its a direct, a scheduled or a periodic task


### PR DESCRIPTION
#175 happens when someone choses a specific engine(and not the random choice). This PR fixes the problem so that when using a non-random engine, assets are correctly filled and they don't get removed after the `update` statement. 