### PR TITLE
Fix var name in add-scan-definition template

### DIFF
--- a/scans/templates/add-scan-definition.html
+++ b/scans/templates/add-scan-definition.html
@@ -221,7 +221,7 @@ label.radio {
 </div>
 
 {{ scan_policies_json|json_script:"scan_policies_json_script" }}
-{{ engine_list|json_script:"engine_list_script" }}
+{{ scan_engines_json|json_script:"engine_list_script" }}
 
 <script>
 


### PR DESCRIPTION
Hi Patrowl team 👋 

It seem that engines list is missing in add-scan-definition template, work again by just changing var name.

Best regards