### PR TITLE
fix(deps): update django_celery_results to 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ coreschema==0.0.4
 Django==2.2.26
 #django-celery-beat==1.1.1
 django-celery-beat==2.0.0
-django-celery-results==2.0.1
+django-celery-results==2.6.0
 django-cursor-pagination==0.1.4
 django-datetime-widget==0.9.3
 django-debug-toolbar==3.2.2


### PR DESCRIPTION
## Summary

Automated dependency update for **django_celery_results**.

> **Security fix** — this update addresses a known CVE vulnerability.

> **Warning:** This fix could not be fully verified because the project's tests were already failing before the update. Please review and run tests manually before merging.

- **Target version:** `2.6.0`
- **Lock regenerated:** No
- **Code modified:** No
- **Tests added:** No
- **All tests pass:** No

## Verification

- **Status:** NOT VERIFIED
- **Summary:** django_celery_results updated to 2.6.0 — NOT verified (tests already failing before update)

- Baseline tests: failing
- Post-fix tests: failing

### Behavioral Comparison

- Output comparison: **SAFE**

## Actions Taken

- :white_check_mark: Updated `django-celery-results==2.0.1` → `django-celery-results==2.6.0`
- :x: Lock regeneration error: [Errno 2] No such file or directory: 'pip-compile'
- :x: Tests failed after update:
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/mrinalhaloi/miniconda3/envs/ai-v2/lib/python3.11/site-packages/_pytest/python.py", line 617, in _importtestmodule
INTERNALERROR>     mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/mrinalhaloi/miniconda3/envs/ai-v2/lib/python3.11/site-packages/_pytest/pathlib.py", line 567

---
*Generated by [fixyou](https://github.com/fixyou)*