### PR TITLE
fix(deps): update gunicorn to 25.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ djangorestframework-datatables==0.6.0
 flower==0.9.2
 future==0.16.0
 futures==3.1.1
-gunicorn==20.0.4
+gunicorn==25.1.0
 idna==2.5
 importlib-metadata==0.23
 itypes==1.1.0


### PR DESCRIPTION
## Summary

Automated dependency update for **gunicorn**.

> **Security fix** — this update addresses a known CVE vulnerability.

> **Warning:** This fix could not be fully verified because the project's tests were already failing before the update. Please review and run tests manually before merging.

- **Target version:** `25.1.0`
- **Lock regenerated:** No
- **Code modified:** No
- **Tests added:** No
- **All tests pass:** No

## Verification

- **Status:** NOT VERIFIED
- **Summary:** gunicorn updated to 25.1.0 — NOT verified (tests already failing before update)

- Baseline tests: failing
- Post-fix tests: failing

### Behavioral Comparison

- Output comparison: **SAFE**

## Actions Taken

- :white_check_mark: Updated `gunicorn==20.0.4` → `gunicorn==25.1.0`
- :x: Lock regeneration error: [Errno 2] No such file or directory: 'pip-compile'
- :x: Tests failed after update:
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/mrinalhaloi/miniconda3/envs/ai-v2/lib/python3.11/site-packages/_pytest/python.py", line 617, in _importtestmodule
INTERNALERROR>     mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/mrinalhaloi/miniconda3/envs/ai-v2/lib/python3.11/site-packages/_pytest/pathlib.py", line 567

---
*Generated by [fixyou](https://github.com/fixyou)*