### PR TITLE
fix(deps): update requests to 2.32.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ python-magic==0.4.15
 #python-magic-bin==0.4.14
 python-memcached==1.59
 pytz==2019.2
-requests==2.25.1
+requests==2.32.5
 simplejson==3.16.0
 singledispatch==3.4.0.3
 six==1.10.0


### PR DESCRIPTION
## Summary

Automated dependency update for **requests**.

> **Security fix** — this update addresses a known CVE vulnerability.

> **Warning:** This fix could not be fully verified because the project's tests were already failing before the update. Please review and run tests manually before merging.

- **Target version:** `2.32.5`
- **Lock regenerated:** No
- **Code modified:** No
- **Tests added:** No
- **All tests pass:** No

## Verification

- **Status:** NOT VERIFIED
- **Summary:** requests updated to 2.32.5 — NOT verified (tests already failing before update)

- Baseline tests: failing
- Post-fix tests: failing

### Behavioral Comparison

- Output comparison: **SAFE**

## Actions Taken

- :white_check_mark: Updated `requests==2.25.1` → `requests==2.32.5`
- :x: Lock regeneration error: [Errno 2] No such file or directory: 'pip-compile'
- :x: Tests failed after update:
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/mrinalhaloi/miniconda3/envs/ai-v2/lib/python3.11/site-packages/_pytest/python.py", line 617, in _importtestmodule
INTERNALERROR>     mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/mrinalhaloi/miniconda3/envs/ai-v2/lib/python3.11/site-packages/_pytest/pathlib.py", line 567

---
*Generated by [fixyou](https://github.com/fixyou)*