### PR TITLE
fix(deps): update urllib3 to 2.6.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ thehive4py==1.8.1
 tornado==5.1
 tzlocal==1.5.1
 uritemplate==3.0.0
-urllib3==1.26.5
+urllib3==2.6.3
 vine==1.3.0
 Werkzeug==2.0.1
 zipp==0.6.0


### PR DESCRIPTION
## Summary

Automated dependency update for **urllib3**.

> **Security fix** — this update addresses a known CVE vulnerability.

> **Warning:** This fix could not be fully verified because the project's tests were already failing before the update. Please review and run tests manually before merging.

- **Target version:** `2.6.3`
- **Lock regenerated:** No
- **Code modified:** No
- **Tests added:** No
- **All tests pass:** No

## Verification

- **Status:** NOT VERIFIED
- **Summary:** urllib3 updated to 2.6.3 — NOT verified (tests already failing before update)

- Baseline tests: failing
- Post-fix tests: failing

### Behavioral Comparison

- Output comparison: **SAFE**

## Actions Taken

- :white_check_mark: Updated `urllib3==1.26.5` → `urllib3==2.6.3`
- :x: Lock regeneration error: [Errno 2] No such file or directory: 'pip-compile'
- :x: Tests failed after update:
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/mrinalhaloi/miniconda3/envs/ai-v2/lib/python3.11/site-packages/_pytest/python.py", line 617, in _importtestmodule
INTERNALERROR>     mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
INTERNALERROR>           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/mrinalhaloi/miniconda3/envs/ai-v2/lib/python3.11/site-packages/_pytest/pathlib.py", line 567

---
*Generated by [fixyou](https://github.com/fixyou)*